### PR TITLE
Add README.md for co2, co2-base, and carbon subprojects

### DIFF
--- a/carbon/README.md
+++ b/carbon/README.md
@@ -1,0 +1,113 @@
+# carbon
+
+Compiler and general-purpose programming language that compiles to C,
+built on top of [libco2](../co2) and [libco2-base](../co2-base). Carbon
+adds classes, interfaces, exceptions, and other syntactic sugar over
+libco2's C object system, then generates plain C source from `.co2`
+files.
+
+Licensed under the GPL.
+
+Note: despite living in this bootstrap repo, Carbon is meant as a real
+general-purpose language, not just an internal build tool — see
+`TODO` for the language roadmap.
+
+## Bootstrap note
+
+The compiler's own sources (`src/co2/*.co2`, e.g. `Compiler.co2`,
+`Grammar.co2`) are themselves written in Carbon, and the compiler links
+against `libco2` and `libco2-base`. A working `carbon` binary must
+already be installed before `carbon` (or `co2-base`) can be rebuilt
+from `.co2` sources — see the top-level [repo README](../README.md) and
+`CLAUDE.md` for the full cycle.
+
+## Installation
+
+```bash
+./autogen.sh
+./configure --prefix=$HOME/local
+make
+make install
+```
+
+`configure` requires `pkg-config` to find `libco2-1.0` and
+`libco2-base-1.0` (set `PKG_CONFIG_PATH` if they're installed to a
+non-default prefix), plus `lex`/`yacc` (or `flex`/`bison`) to build the
+lexer/parser. Installing produces the `carbon` binary and a
+`carbon-1.0.pc` pkg-config file.
+
+For quick iteration inside `src/` without a full `configure`:
+
+```bash
+cd src
+./build.sh          # runs make -k twice, past the .co2-generation pass
+./build.sh clean     # removes generated .c/.h sources
+```
+
+## Usage
+
+```
+carbon [OPTION]... [SOURCE_FILE] [C_OUTPUT_FILE]
+
+ARGUMENTS:
+        SOURCE_FILE:    carbon source file
+        C_OUTPUT_FILE:  filename of c output
+
+OPTIONS:
+        -I INCLUDE_DIR: include directory to add to search path
+        -h,--help:      show this help
+        -V,--version:   show version
+        -d,--depend:    show dependencies
+```
+
+Example, `MyObject.co2`:
+
+```
+class MyObject {
+	int value;
+
+	MyObject(int value) {
+		self.value = value;
+	}
+
+	int getValue() {
+		return value;
+	}
+
+	int setValue(int value) {
+		return self.value = value;
+	}
+}
+```
+
+Compile it to C, then build against `libco2`:
+
+```bash
+carbon MyObject.co2 MyObject.c
+gcc $(pkg-config --cflags --libs libco2-1.0) MyObject.c main.c -o myapp
+```
+
+A complete, buildable example project is in
+[`examples/my-object-carbon`](../examples/my-object-carbon).
+
+## Tests
+
+Custom shell-driven suite (not wired into `make check`):
+
+```bash
+cd test
+./run_tests.sh
+```
+
+Runs every `*.test` file under `test/pass/` (must compile and run
+successfully) and `test/fail/` (must fail to compile) against the
+freshly built `../src/carbon` binary, logging results to
+`test/target/`. Run a single test directly with:
+
+```bash
+./run_pass_test.sh path/to/file.test
+./run_fail_test.sh path/to/file.test
+```
+
+`generate-testcases.sh` / `generate-makefile-am.sh` regenerate the test
+list after adding or removing `.test` files.

--- a/co2-base/README.md
+++ b/co2-base/README.md
@@ -1,0 +1,112 @@
+# libco2-base
+
+Collections and utility library for [libco2](../co2): array lists, double
+linked lists, hash maps, strings, logging, exceptions, and more. Written
+in the **Carbon language** (`.co2` files under `src/co2/`) and compiled
+to plain C by the `carbon` compiler.
+
+Licensed under the LGPL.
+
+## Bootstrap note
+
+Building this project from `.co2` sources requires an already-installed
+`carbon` compiler (found via `PATH`/`configure`). See the top-level
+[repo README](../README.md) and `CLAUDE.md` for the full bootstrap-cycle
+explanation: `carbon` itself depends on `libco2-base` to build, so a
+prior release of `carbon` must be installed first.
+
+## Features
+
+Selected classes from `src/co2/` (each `X.co2` compiles to `X.c`/`X.h`):
+
+- Collections: `Array`, `ArrayList`, `ArrayIterator`, `DoubleLinkedList`,
+  `DoubleLinkedListIterator`, `DoubleLinkedItem`, `HashMap`, `RefList`
+- Interfaces: `Collection`, `Comparable`, `Iterable`, `List`
+- Core types: `RefObject`, `BaseObject`, `String`, `Enum`
+- Exceptions: `Exception`, `ClassCastException`
+- Logging: `Logger`, `ConsoleHandler`
+
+## Installation
+
+```bash
+./autogen.sh
+./configure --prefix=$HOME/local
+make
+make install
+```
+
+`configure` requires `libco2-1.0` to be discoverable via `pkg-config`
+(set `PKG_CONFIG_PATH` if `libco2` is installed to a non-default
+prefix), and requires a `carbon` binary on `PATH` to regenerate the
+`.c`/`.h` files from `.co2` sources if they are not already present.
+Installing produces a `libco2-base-1.0.pc` pkg-config file for
+downstream projects.
+
+For quick iteration inside `src/` without a full `configure`, use:
+
+```bash
+cd src
+./build.sh          # runs make -k twice, past the .co2-generation pass
+./build.sh clean     # removes generated .c/.h sources
+```
+
+## Usage example
+
+`ArrayList` written in Carbon (`src/co2/ArrayList.co2`, abbreviated):
+
+```
+include co2/Array
+include co2/List
+
+class ArrayList : Array, List {
+	unsigned length;
+
+	ArrayList () {
+		super (128);
+		length = 0;
+	}
+
+	RefObject add(RefObject item) {
+		ensure (length + 1);
+		set (length, item);
+		length += 1;
+		return item;
+	}
+
+	Iterator iterator () {
+		return new ArrayIterator (self);
+	}
+}
+```
+
+Using the compiled result from C:
+
+```c
+#include "co2/ArrayList.h"
+#include "co2/String.h"
+
+void *list = new(ArrayList());
+add(list, new(String(), "hello"));
+add(list, new(String(), "world"));
+
+void *it = iterator(list);
+while (hasNext(it)) {
+	void *item = next(it);
+	printf("%s\n", c_str(item));
+}
+delete(it);
+delete(list);
+```
+
+Compile against both libraries:
+
+```bash
+gcc $(pkg-config --cflags --libs libco2-1.0 libco2-base-1.0) main.c -o myapp
+```
+
+## Tests
+
+```bash
+cd test
+make check
+```

--- a/co2/README.md
+++ b/co2/README.md
@@ -1,0 +1,114 @@
+# libco2
+
+Object system for plain C. Gives C classes, interfaces, singletons, and
+exceptions, no code generation needed — everything is plain macros and
+structs. Foundation library for the [co2 project family](../README.md)
+(`co2-base` and the `carbon` compiler are both built on top of it).
+
+Licensed under the LGPL.
+
+## Features
+
+- **Classes** with single inheritance and virtual methods (`O_CLASS`,
+  `O_METHOD_DEF`, `O_IMPLEMENT`, `O_OBJECT` / `O_OBJECT_END`)
+- **Interfaces** or protocols independent of the class hierarchy
+- **Singletons**
+- **Exceptions** (`co2_exception.h`)
+- Small set of general helpers (`utils.h`)
+
+Core headers live in `src/co2/`: `Object.h`, `Interface.h`, `Singleton.h`,
+`co2_exception.h`, `utils.h`.
+
+## Installation
+
+Standard GNU Autotools build:
+
+```bash
+./autogen.sh
+./configure --prefix=$HOME/local
+make
+make install
+```
+
+This installs the library and headers plus a `libco2-1.0.pc` pkg-config
+file. If you install outside a default prefix, make sure
+`PKG_CONFIG_PATH` includes `$PREFIX/lib/pkgconfig` so other projects
+(`co2-base`, `carbon`) can find `libco2-1.0` via `pkg-config`.
+
+## Usage example
+
+A minimal class definition, `MyObject.h`:
+
+```c
+#include "co2/Object.h"
+
+O_METHOD_DEF(MyObject, int, getValue, (void *_self));
+O_METHOD_DEF(MyObject, int, setValue, (void *_self, int value));
+
+#define MyObjectClass_Attr			\
+	ObjectClass_Attr;			\
+	O_METHOD(MyObject, getValue);		\
+	O_METHOD(MyObject, setValue)
+
+#define MyObject_Attr				\
+	Object_Attr;				\
+	int value
+
+O_CLASS(MyObject, Object);
+```
+
+and `MyObject.c`:
+
+```c
+#include "MyObject.h"
+
+#define O_SUPER Object()
+
+O_IMPLEMENT(MyObject, void *, ctor, (void *_self, va_list * argp)) {
+	struct MyObject *self = O_CAST(_self, MyObject());
+	self->value = va_arg(*argp, int);
+	return self;
+}
+
+O_IMPLEMENT(MyObject, int, getValue, (void *_self)) {
+	struct MyObject *self = O_CAST(_self, MyObject());
+	return self->value;
+}
+
+O_IMPLEMENT(MyObject, int, setValue, (void *_self, int value)) {
+	struct MyObject *self = O_CAST(_self, MyObject());
+	self->value = value;
+	return value;
+}
+
+O_OBJECT(MyObject, Object);
+O_OBJECT_METHOD(MyObject, ctor);
+O_OBJECT_METHOD(MyObject, getValue);
+O_OBJECT_METHOD(MyObject, setValue);
+O_OBJECT_END
+```
+
+Used like any other C object:
+
+```c
+void *obj = new(MyObject(), 42);
+int v = getValue(obj);
+setValue(obj, v + 1);
+delete(obj);
+```
+
+Compile against libco2 with pkg-config:
+
+```bash
+gcc $(pkg-config --cflags --libs libco2-1.0) MyObject.c main.c -o myapp
+```
+
+A complete, buildable version of this example is in
+[`examples/my-object`](../examples/my-object).
+
+## Tests
+
+```bash
+cd test
+make check
+```


### PR DESCRIPTION
## Summary
- Add `co2/README.md`, `co2-base/README.md`, `carbon/README.md` (each previously had only an empty `README` stub)
- Each covers: purpose, key features/classes, install steps (autogen/configure/make), a runnable usage example, and how to run that project's test suite

## Test plan
- [x] Reviewed content against `configure.ac`, source layout, and existing example projects for accuracy
- [x] Skim-read each README as a newcomer would

🤖 Generated with [Claude Code](https://claude.com/claude-code)